### PR TITLE
添加Phi3模型路径配置

### DIFF
--- a/Phi3mini.py
+++ b/Phi3mini.py
@@ -5,6 +5,9 @@ from io import BytesIO
 from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
 
 
+import folder_paths
+
+
 class Phi3mini_4k_ModelLoader_Zho:
     def __init__(self):
         pass
@@ -23,13 +26,16 @@ class Phi3mini_4k_ModelLoader_Zho:
     CATEGORY = "🏖️Phi3mini"
   
     def load_model(self,):
+        model_path = "microsoft/Phi-3-mini-4k-instruct"
+        if "Phi3_model" in folder_paths.folder_names_and_paths:
+            model_path = folder_paths.folder_names_and_paths['Phi3_model'][0][0]
         model = AutoModelForCausalLM.from_pretrained(
-            "microsoft/Phi-3-mini-4k-instruct", 
+            model_path, 
             device_map="cuda", 
             torch_dtype="auto", 
             trust_remote_code=True, 
         )
-        tokenizer = AutoTokenizer.from_pretrained("microsoft/Phi-3-mini-4k-instruct")
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
         return model, tokenizer
 
 


### PR DESCRIPTION
允许从本地指定路径加载模型。

通过配置extra_model_paths.yaml来指定Phi3模型的路径，也可以通过此法切换不同尺寸的Phi3模型。配置项如下：

```yaml
comfyui:
    Phi3_model: /path/to/Phi3/model/dir/
```